### PR TITLE
Using CommonCrypto instead of CCommonCrypto

### DIFF
--- a/Sources/CommonCrypto/module.modulemap
+++ b/Sources/CommonCrypto/module.modulemap
@@ -1,4 +1,4 @@
-module CCommonCrypto {
+module CommonCrypto {
     header "/usr/include/CommonCrypto/CommonCrypto.h"
     export *
 }

--- a/Sources/HMAC/HMACCrypto.swift
+++ b/Sources/HMAC/HMACCrypto.swift
@@ -1,5 +1,5 @@
 import Foundation
-import CCommonCrypto
+import CommonCrypto
 
 public enum HMACAlgorithm {
     case sha256

--- a/Sources/RSA/NSDataExtension.swift
+++ b/Sources/RSA/NSDataExtension.swift
@@ -7,7 +7,7 @@
 //
 
 import Foundation
-import CCommonCrypto
+import CommonCrypto
 
 extension NSData {
     var sha1: Data {

--- a/SwiftyCrypto.xcodeproj/project.pbxproj
+++ b/SwiftyCrypto.xcodeproj/project.pbxproj
@@ -144,7 +144,7 @@
 		B79CC85A2050CDF3006B71DB /* Sources */ = {
 			isa = PBXGroup;
 			children = (
-				B7B209B82043F6C5003BB264 /* CCommonCrypto */,
+				B7B209B82043F6C5003BB264 /* CommonCrypto */,
 				B7B209AC2043BB4F003BB264 /* HMAC */,
 				B7B2096120417799003BB264 /* protocol */,
 				B7B2095820417799003BB264 /* RSA */,
@@ -260,12 +260,12 @@
 			path = HMAC;
 			sourceTree = "<group>";
 		};
-		B7B209B82043F6C5003BB264 /* CCommonCrypto */ = {
+		B7B209B82043F6C5003BB264 /* CommonCrypto */ = {
 			isa = PBXGroup;
 			children = (
 				B7B209B72043F64B003BB264 /* module.modulemap */,
 			);
-			path = CCommonCrypto;
+			path = CommonCrypto;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */


### PR DESCRIPTION
Make necessary renames to ensure the use of CommonCrypto instead of CCommonCrypto