### PR TITLE
Enable Swift Package Manager compatibility

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,40 @@
+// swift-tools-version:5.3
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+private let target = Target.target(
+    name: "SwiftyCrypto",
+    dependencies: [],
+    path: "Sources")
+
+
+private let testTarget = Target.testTarget(
+    name: "SwiftyCryptoTests",
+    dependencies: ["SwiftyCrypto"],
+    path: "SwiftyCryptoTests",
+    exclude: [
+        "Info.plist",
+        "RSA/private.txt",
+        "RSA/private.pem",
+        "RSA/public.txt",
+        "RSA/public.pem",
+        "RSA/RSAKeySigningTests.swift"
+    ],
+    sources: [
+        "HMAC-Based/HMACTests.swift",
+        "RSA/RSAMessageTests.swift"
+    ])
+
+let package = Package(
+    name: "SwiftyCrypto",
+    platforms: [.iOS(.v11), .macOS(.v10_12)],
+    products: [
+        .library(
+            name: "SwiftyCrypto",
+            targets: ["SwiftyCrypto"]),
+    ],
+    dependencies: [
+    ],
+    targets: [target, testTarget]
+)

--- a/Sources/RSA/RSAKeyFactory.swift
+++ b/Sources/RSA/RSAKeyFactory.swift
@@ -6,6 +6,8 @@
 //  Copyright © 2018年 Yufu. All rights reserved.
 //
 
+import Foundation
+
 public enum SwiftyCryptoRSAKeySize: Int {
     case RSAKey64 = 512
     case RSAKey128 = 1024

--- a/SwiftyCryptoTests/HMAC-Based/HMACTests.swift
+++ b/SwiftyCryptoTests/HMAC-Based/HMACTests.swift
@@ -7,6 +7,9 @@
 //
 
 import XCTest
+#if SWIFT_PACKAGE
+@testable import SwiftyCrypto
+#endif
 
 class HMACTests: XCTestCase {
     


### PR DESCRIPTION
Created **Package.swift**

Excluded **RSAKeySigningTests** from Swift Package Manager
> SPM testing environment isn't a host device with a proper keychain mechanism
> The test can still be executed on the underlying **SwiftyCryptoTests** inside **SwiftyCrypto.xcodeproj**

Fixed tests